### PR TITLE
We're not using SimpleHTTPServer anymore.

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -267,7 +267,7 @@ needed by Pelican.
 
     automation = ask('Do you want to generate a Fabfile/Makefile '
                      'to automate generation and publishing?', bool, True)
-    develop = ask('Do you want an auto-reload & simpleHTTP script '
+    develop = ask('Do you want an auto-reload & simple HTTP script '
                   'to assist with theme and site development?', bool, True)
 
     if automation:


### PR DESCRIPTION
In `pelican_quickstart.py`, there is still `simpleHTTP` in the question for `develop` option. I'm pretty sure that it means `SimpleHTTPServer` of Python 2. We have to change it into `simple HTTP` to clarify.